### PR TITLE
MM-32823: fix _redirect handling

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -31,6 +31,7 @@ type Plugin struct {
 	github *github.Client
 }
 
+// OnActivate is called by the server when a plugin starts.
 func (p *Plugin) OnActivate() error {
 	config := p.getConfiguration()
 	if err := config.IsValid(); err != nil {
@@ -58,6 +59,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	}
 }
 
+// CreateAPIRequest models incoming create requests.
 type CreateAPIRequest struct {
 	Type   string `json:"type"`
 	Title  string `json:"title"`
@@ -172,8 +174,8 @@ func (p *Plugin) handleCreate(w http.ResponseWriter, r *http.Request) {
 	)
 
 	issueRequest := &github.IssueRequest{
-		Title:  NewString("Request for Documentation: " + createRequest.Title),
-		Body:   NewString(body),
+		Title:  newString("Request for Documentation: " + createRequest.Title),
+		Body:   newString(body),
 		Labels: &labels,
 	}
 
@@ -199,4 +201,4 @@ func (p *Plugin) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func NewString(s string) *string { return &s }
+func newString(s string) *string { return &s }


### PR DESCRIPTION
#### Summary
A long time ago, `_redirect` was pitched as a general solution to linking to a permalink post. Unfortunately, the actual implementation really only supported DMs and GMs, with permalinks to posts in channels other than the currently visible team failing to resolve properly. Change this plugin to only rely on `_redirect` when actually needed, avoiding this edge case. (The work to make `_redirect` work properly in all cases remains unscoped at this time.) 

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-32823